### PR TITLE
Support R syntax highlighting in R("""-blocks

### DIFF
--- a/snakemake-mode.el
+++ b/snakemake-mode.el
@@ -6,7 +6,7 @@
 ;; URL: https://github.com/kyleam/snakemake-mode
 ;; Keywords: tools
 ;; Version: 0.3.0
-;; Package-Requires: ((emacs "24") (cl-lib "0.5") (magit-popup "2.4.0"))
+;; Package-Requires: ((emacs "24") (cl-lib "0.5") (magit-popup "2.4.0") (mmm-mode "0.5.4"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -321,6 +321,19 @@ label."
                                   (point-marker)))
             index))
     (nreverse index)))
+
+
+;;; Syntax-highlight embedded R code
+(require 'mmm-mode)
+(setq mmm-global-mode 'maybe)
+
+(mmm-add-classes
+ '((snakemake-R
+    :submode R-mode
+    :front ".*R\(\"\"\""
+    :back ".*\"\"\"\)")))
+
+(mmm-add-mode-ext-class 'snakemake-mode nil 'snakemake-R)
 
 
 ;;; Mode

--- a/snakemake.el
+++ b/snakemake.el
@@ -350,6 +350,20 @@ targets."
                                        (snakemake-all-rules))
              " "))
 
+
+
+(defun snakemake-graph-workflow ()
+  (interactive)
+  """Creates a graph for the current snakefile."""
+  (let ((dot (shell-command-to-string "which dot")))
+    (when (equal dot "")
+      (error "You do not have dot (graphviz) on your emacs path!")))
+  (let* ((fname (buffer-file-name))
+         (graphname (concat (buffer-file-name) ".pdf"))
+         (graph-command (concat "snakemake --dag --snakefile " fname " | dot -Tpdf > " graphname)))
+    (shell-command graph-command)))
+
+
 
 ;;; Compilation commands
 


### PR DESCRIPTION
Uses purcells robust mmm-library: https://github.com/purcell/mmm-mode

Can be further updated to recognize other strings as embedded R. The template should be easy to follow.

I suggest something like `"""#[Rr]` for the case where you need to run R-scripts using shell or write them in a variable to print/debug. But I leave it at your discretion.

Use-cases for suggestion above:

```python
        command = """#r
        library(csaw)
        param = readParam(minq=50, restrict=c({chromosomes_as_string}))"""
        print(command)
        R(command)
```

or 

```python
        run_voom_script = """#R
        library(edgeR)
        normfactors = tail(read.table("{input.normalization_file}", row.names=1, header=F), 18)
        colnames(normfactors) = c("norm.factors") # need this name for voom to accept the normfactors
        df = read.table("{input.infile}")

        x = DGEList(counts=df, norm.factors=as.matrix(normfactors))

        y = voom(x)
        write.table(y$E, "{output.outfile}", sep=" ")
        """.format(**locals())

        print(run_voom_script)

        # Must craete new instance of R-interpreter to avoid clashing library requirements
        with open(output.script, "w+") as script_handle:
            script_handle.write(run_voom_script)

        shell("Rscript {output.script}")
```